### PR TITLE
readded timestamp logic that got lost in last merge/pr

### DIFF
--- a/internal/driver/readhandler.go
+++ b/internal/driver/readhandler.go
@@ -154,9 +154,13 @@ func makeReadRequest(deviceClient *opcua.Client, req sdkModel.CommandRequest) (*
 		return nil, fmt.Errorf("Driver.handleReadCommands: Status not OK: %v", resp.Results[0].Status)
 	}
 
-	// make new result
-	reading := resp.Results[0].Value.Value()
-	return newResult(req, reading)
+	result, err := newResult(req, reading)
+
+	// get source timestamp
+	sourceTimeStamp := extractSourceTimestamp(resp.Results[0])
+	result.Tags["source timestamp"] = sourceTimeStamp.String()
+
+	return result, err
 }
 
 func makeMethodCall(deviceClient *opcua.Client, req sdkModel.CommandRequest) (*sdkModel.CommandValue, error) {
@@ -205,7 +209,12 @@ func makeMethodCall(deviceClient *opcua.Client, req sdkModel.CommandRequest) (*s
 		return nil, fmt.Errorf("Driver.handleReadCommands: Method status not OK: %v", resp.StatusCode)
 	}
 
-	return newResult(req, resp.OutputArguments[0].Value())
+	result, err := newResult(req, resp.OutputArguments[0].Value())
+	// get source timestamp
+	sourceTimeStamp := extractSourceTimestamp(resp.OutputArguments[0].DataValue())
+	result.Tags["source timestamp"] = sourceTimeStamp.String()
+
+	return result, err
 }
 
 func generateCert() (*tls.Certificate, error) {


### PR DESCRIPTION
readded timestamp logic to readhandler

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
