### PR TITLE
Feature/ep 205 ba660(siemens) machine configuration

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -16,15 +16,15 @@ FailWaitTime = 10
 Type = "consul"
 
 [Clients]
-  [Clients.core-data]
-  Protocol = "http"
-  Host = "localhost"
-  Port = 59880
+[Clients.core-data]
+Protocol = "http"
+Host = "localhost"
+Port = 59880
 
-  [Clients.core-metadata]
-  Protocol = "http"
-  Host = "localhost"
-  Port = 59881
+[Clients.core-metadata]
+Protocol = "http"
+Host = "localhost"
+Port = 59881
 
 [MessageQueue]
 Protocol = "redis"
@@ -34,17 +34,17 @@ Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
 PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
-  [MessageQueue.Optional]
-  # Default MQTT Specific options that need to be here to enable environment variable overrides of them
-  # Client Identifiers
-  ClientId = "device-opcua"
-  # Connection information
-  Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
-  KeepAlive = "10" # Seconds (must be 2 or greater)
-  Retained = "false"
-  AutoReconnect = "true"
-  ConnectTimeout = "5" # Seconds
-  SkipCertVerify = "false" # Only used if Cert/Key file or Cert/Key PEMblock are specified  [MessageQueue.Optional]
+[MessageQueue.Optional]
+# Default MQTT Specific options that need to be here to enable environment variable overrides of them
+# Client Identifiers
+ClientId = "device-opcua"
+# Connection information
+Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+KeepAlive = "10" # Seconds (must be 2 or greater)
+Retained = "false"
+AutoReconnect = "true"
+ConnectTimeout = "5" # Seconds
+SkipCertVerify = "false" # Only used if Cert/Key file or Cert/Key PEMblock are specified  [MessageQueue.Optional]
 
 [Device]
 DataTransform = true
@@ -67,45 +67,37 @@ Protocol = "http"
 RootCaCertPath = ""
 ServerName = ""
 TokenFile = "/tmp/edgex/secrets/device-opcua/secrets-token.json"
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
+[SecretStore.Authentication]
+AuthType = "X-Vault-Token"
 
 [Writable]
 LogLevel = "INFO"
-  # InsecureSecrets are required for when Redis is used for message bus
-  [Writable.InsecureSecrets]
-    [Writable.InsecureSecrets.DB]
-    path = "redisdb"
-      [Writable.InsecureSecrets.DB.Secrets]
-      username = ""
-      password = ""
-    [Writable.InsecureSecrets.OPCUA]
-    path = "credentials"
-      [Writable.InsecureSecrets.OPCUA.Secrets]
-      username = "bTrace"
-      password = "23556"
+# InsecureSecrets are required for when Redis is used for message bus
+[Writable.InsecureSecrets]
+[Writable.InsecureSecrets.DB]
+path = "redisdb"
+[Writable.InsecureSecrets.DB.Secrets]
+username = ""
+password = ""
+[Writable.InsecureSecrets.OPCUA]
+path = "credentials"
+[Writable.InsecureSecrets.OPCUA.Secrets]
+username = ""
+password = ""
 
 # Driver configs
 [OPCUAServer]
-DeviceName = "BA660_Simulation"  # Name of existing Device
-Endpoint = "opc.tcp://10.249.81.40:4840"# endpoint of existing Device
-Policy = "Basic256Sha256"                        # Security policy: None, Basic128Rsa15, Basic256, Basic256Sha256. Default: None
-Mode = "SignAndEncrypt"                          # Security mode: None, Sign, SignAndEncrypt. Default: None
+DeviceName = ""  # Name of existing Device
+Endpoint = ""# endpoint of existing Device
+Policy = "None"                        # Security policy: None, Basic128Rsa15, Basic256, Basic256Sha256. Default: None
+Mode = "None"                          # Security mode: None, Sign, SignAndEncrypt. Default: None
+CertFile = ""                          # Path to cert.pem. Required for security mode/policy != None
+KeyFile = ""                           # Path to private key.pem. Required for security mode/policy != None
 CredentialsRetryTime = 120 # Seconds
 CredentialsRetryWait = 1 # Seconds
 ConnEstablishingRetry = 10
 ConnRetryWaitTime = 5
 CredentialsPath = "credentials"
-  [OPCUAServer.CertificateConfig]
-  CertFile = "/res/certs/client-cert.pem"                           # Path to cert.pem. Required for security mode/policy != None , since we create the certificate with every connection there is no stored CertFile
-  KeyFile = "/res/certs/client-key.pem"                            # Path to private key.pem. Required for security mode/policy != None, since we create the certificate with every connection there is no stored KeyFile
-  CertOrganization = "Baader.com"
-  CertCountry = "DE"
-  CertProvince = "Hamburg"
-  CertLocality = "Hamburg"
-  CertCommonName = "urn:localhost"
-  CertBits = 2048
-  CertFilePermissions = "644" #root permissions for reading and writing the certificate and key files
-  [OPCUAServer.Writable]
-  # Device resources related to Node IDs to subscribe to (comma-separated values)
-  Resources = "DeviceNumber,CurrentMachineSpeed,RequestedMachineSpeed,MachineState,ProductCounter"
+[OPCUAServer.Writable]
+# Device resources related to Node IDs to subscribe to (comma-separated values)
+Resources = "DeviceNo,CurMachSpeed,MachSpeed,StateCurrent,UnitModeCurrent,ProdProcessedCount,ProdDefectiveCount"

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -16,15 +16,15 @@ FailWaitTime = 10
 Type = "consul"
 
 [Clients]
-[Clients.core-data]
-Protocol = "http"
-Host = "localhost"
-Port = 59880
+  [Clients.core-data]
+  Protocol = "http"
+  Host = "localhost"
+  Port = 59880
 
-[Clients.core-metadata]
-Protocol = "http"
-Host = "localhost"
-Port = 59881
+  [Clients.core-metadata]
+  Protocol = "http"
+  Host = "localhost"
+  Port = 59881
 
 [MessageQueue]
 Protocol = "redis"
@@ -34,17 +34,17 @@ Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
 PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
-[MessageQueue.Optional]
-# Default MQTT Specific options that need to be here to enable environment variable overrides of them
-# Client Identifiers
-ClientId = "device-opcua"
-# Connection information
-Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
-KeepAlive = "10" # Seconds (must be 2 or greater)
-Retained = "false"
-AutoReconnect = "true"
-ConnectTimeout = "5" # Seconds
-SkipCertVerify = "false" # Only used if Cert/Key file or Cert/Key PEMblock are specified  [MessageQueue.Optional]
+  [MessageQueue.Optional]
+  # Default MQTT Specific options that need to be here to enable environment variable overrides of them
+  # Client Identifiers
+  ClientId = "device-opcua"
+  # Connection information
+  Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+  KeepAlive = "10" # Seconds (must be 2 or greater)
+  Retained = "false"
+  AutoReconnect = "true"
+  ConnectTimeout = "5" # Seconds
+  SkipCertVerify = "false" # Only used if Cert/Key file or Cert/Key PEMblock are specified  [MessageQueue.Optional]
 
 [Device]
 DataTransform = true
@@ -67,37 +67,45 @@ Protocol = "http"
 RootCaCertPath = ""
 ServerName = ""
 TokenFile = "/tmp/edgex/secrets/device-opcua/secrets-token.json"
-[SecretStore.Authentication]
-AuthType = "X-Vault-Token"
+  [SecretStore.Authentication]
+  AuthType = "X-Vault-Token"
 
 [Writable]
 LogLevel = "INFO"
-# InsecureSecrets are required for when Redis is used for message bus
-[Writable.InsecureSecrets]
-[Writable.InsecureSecrets.DB]
-path = "redisdb"
-[Writable.InsecureSecrets.DB.Secrets]
-username = ""
-password = ""
-[Writable.InsecureSecrets.OPCUA]
-path = "credentials"
-[Writable.InsecureSecrets.OPCUA.Secrets]
-username = ""
-password = ""
+  # InsecureSecrets are required for when Redis is used for message bus
+  [Writable.InsecureSecrets]
+    [Writable.InsecureSecrets.DB]
+    path = "redisdb"
+      [Writable.InsecureSecrets.DB.Secrets]
+      username = ""
+      password = ""
+    [Writable.InsecureSecrets.OPCUA]
+    path = "credentials"
+      [Writable.InsecureSecrets.OPCUA.Secrets]
+      username = "bTrace"
+      password = "23556"
 
 # Driver configs
 [OPCUAServer]
-DeviceName = ""  # Name of existing Device
-Endpoint = ""# endpoint of existing Device
-Policy = "None"                        # Security policy: None, Basic128Rsa15, Basic256, Basic256Sha256. Default: None
-Mode = "None"                          # Security mode: None, Sign, SignAndEncrypt. Default: None
-CertFile = ""                          # Path to cert.pem. Required for security mode/policy != None
-KeyFile = ""                           # Path to private key.pem. Required for security mode/policy != None
+DeviceName = "BA660_Simulation"  # Name of existing Device
+Endpoint = "opc.tcp://10.249.81.40:4840"# endpoint of existing Device
+Policy = "Basic256Sha256"                        # Security policy: None, Basic128Rsa15, Basic256, Basic256Sha256. Default: None
+Mode = "SignAndEncrypt"                          # Security mode: None, Sign, SignAndEncrypt. Default: None
 CredentialsRetryTime = 120 # Seconds
 CredentialsRetryWait = 1 # Seconds
 ConnEstablishingRetry = 10
 ConnRetryWaitTime = 5
 CredentialsPath = "credentials"
-[OPCUAServer.Writable]
-# Device resources related to Node IDs to subscribe to (comma-separated values)
-Resources = "DeviceNo,CurMachSpeed,MachSpeed,StateCurrent,UnitModeCurrent,ProdProcessedCount,ProdDefectiveCount"
+  [OPCUAServer.CertificateConfig]
+  CertFile = "/res/certs/client-cert.pem"                           # Path to cert.pem. Required for security mode/policy != None , since we create the certificate with every connection there is no stored CertFile
+  KeyFile = "/res/certs/client-key.pem"                            # Path to private key.pem. Required for security mode/policy != None, since we create the certificate with every connection there is no stored KeyFile
+  CertOrganization = "Baader.com"
+  CertCountry = "DE"
+  CertProvince = "Hamburg"
+  CertLocality = "Hamburg"
+  CertCommonName = "urn:localhost"
+  CertBits = 2048
+  CertFilePermissions = "644" #root permissions for reading and writing the certificate and key files
+  [OPCUAServer.Writable]
+  # Device resources related to Node IDs to subscribe to (comma-separated values)
+  Resources = "DeviceNumber,CurrentMachineSpeed,RequestedMachineSpeed,MachineState,ProductCounter"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type CertificateConfiguration struct {
 	CertCountry         string
 	CertProvince        string
 	CertLocality        string
+	CertCommonName      string
 	CertBits            int
 	CertFilePermissions string
 	KeyFile             string


### PR DESCRIPTION
Added properties that were added to "created-certificates.sh" in https://dev.azure.com/Baader-Digitalization/bOne-platform/_git/bOne-platform/pullrequest/212 also to go code so the fallback will still work with ba660(siemens)

# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions
1. Check out bone platform repo on develop after https://dev.azure.com/Baader-Digitalization/bOne-platform/_git/bOne-platform/pullrequest/212 is merged into b-one platform or check out the branch 205 directly.
2. bind the current PR image of device opcua into the docker-compose.device-opcua.yml
3. start the gateway against ba660_siemens machine
4. delete the scripts in "device-service-opcua-go-config/certs"...these were created by our bashscript "create-certificates.sh". 5.Now the opcua device will create new certificates(see also logs)
5. subscriptions and reads should work as expected and be forwarded to ekuiper and mosquitto

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
