### PR TITLE
EP:590 Change settings in the Writable section of opc ua device service will result in an endless restart modus of the opc ua connection

### DIFF
--- a/internal/driver/subscriptionlistener.go
+++ b/internal/driver/subscriptionlistener.go
@@ -147,6 +147,7 @@ func InitCheckClientState(d *Driver, client ClientState) {
 	for {
 		// break this routine if subscription was canceled
 		if subCanceled {
+			d.Logger.Infof("Break connection state checking because subscription was cancelled.")
 			break
 		}
 

--- a/internal/driver/subscriptionlistener.go
+++ b/internal/driver/subscriptionlistener.go
@@ -22,6 +22,7 @@ import (
 
 var LastClientState opcua.ConnState
 var ActualClientState opcua.ConnState
+var subCanceled bool
 var basicErrorMessage = "[Incoming listener] unable to get running device service"
 
 func (d *Driver) StartSubscriptionListener() error {
@@ -41,7 +42,7 @@ func (d *Driver) StartSubscriptionListener() error {
 	ctxBg := context.Background()
 	ctx, cancel := context.WithCancel(ctxBg)
 	d.CtxCancel = cancel
-
+	subCanceled = false
 	ds := service.RunningService()
 	if ds == nil {
 		return fmt.Errorf(basicErrorMessage)
@@ -128,6 +129,9 @@ func CloseClientConnection(d *Driver, client ClientCloser) error {
 // CancelSubscription cancel the subscription
 func CancelSubscription(d *Driver, cancel SubscriptionCanceller, ctx context.Context) error {
 	err := cancel.Cancel(ctx)
+	subCanceled = true
+	LastClientState = opcua.Closed
+	ActualClientState = opcua.Closed
 	if err != nil {
 		d.Logger.Warnf("[Incoming listener] Failed to cancel subscription., %s", err)
 	}
@@ -141,6 +145,11 @@ func InitCheckClientState(d *Driver, client ClientState) {
 	LastClientState = opcua.Closed
 	ActualClientState = opcua.Closed
 	for {
+		// break this routine if subscription was canceled
+		if subCanceled {
+			break
+		}
+
 		// separated into a function for better testability
 		HandleCurrentClientState(d, client)
 		// use configured interval


### PR DESCRIPTION
cancel client inquiry go routine when subscription gets canceled

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

- Start gateway using any connection(581, 660(Siemens only)
- verify subcriptions are reading values
- go into consul and edit username and/or password of opcua device service  to something wrong and save
- opcua device logs an error message that the userIdentityToken is invalid -> meaning the credentials are wrong
- change credentials back again
- verify the subscriptions work as intended again and that the looping logs don't appear
- for safety: repeat the step one or tqo times more

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
