### PR TITLE
Bug/ep 694 wrong resource breaks device service subscription

### DIFF
--- a/internal/driver/subscriptionlistener.go
+++ b/internal/driver/subscriptionlistener.go
@@ -200,9 +200,9 @@ func (d *Driver) ConfigureMonitoredItems(sub *opcua.Subscription, resources, dev
 	for i, node := range strings.Split(resources, ",") {
 		deviceResource, ok := ds.DeviceResource(deviceName, node)
 		if !ok {
-			// If a resource is missing, skip it so subscriptions for the other resources can run.
-			d.Logger.Infof("[Incoming listener] Unable to find device resource with name %s", node)
-			break
+			// If a resource is not found, skip it so subscriptions for the other resources can run.
+			d.Logger.Infof("[Incoming listener] Unable to find device resource with name %s. Please check the device profile.", node)
+			continue
 		}
 
 		opcuaNodeID, err := GetNodeID(deviceResource.Attributes, NODE)

--- a/internal/driver/subscriptionlistener.go
+++ b/internal/driver/subscriptionlistener.go
@@ -77,7 +77,7 @@ func (d *Driver) StartSubscriptionListener() error {
 	// begin continuous client state check
 	go InitCheckClientState(d, client)
 
-	if err = d.ConfigureMonitoredItems(sub, ds, resources, deviceName); err != nil {
+	if err = d.ConfigureMonitoredItems(sub, resources, deviceName); err != nil {
 		return err
 	}
 
@@ -107,11 +107,6 @@ type ClientState interface {
 	State() opcua.ConnState
 }
 
-// RunningService capsules the containing method for easy mocking in unit tests
-var (
-	RunningService = service.RunningService
-)
-
 // ClientCloser interface gives us possibility to mock opcua client functions for closing a client in tests.
 type ClientCloser interface {
 	Close() error
@@ -120,11 +115,6 @@ type ClientCloser interface {
 // SubscriptionCanceller interface gives us possibility to mock opcua client functions for cling a client in tests.
 type SubscriptionCanceller interface {
 	Cancel(ctx context.Context) error
-}
-
-// SubscriptionCanceller interface gives us possibility to mock opcua client functions for cling a client in tests.
-type REsourceGetter interface {
-	DeviceResource(name1 string, name2 string) (models.DeviceResource, bool)
 }
 
 // CloseClientConnection tries to close the client connection
@@ -197,18 +187,22 @@ func (d *Driver) GetClient(device models.Device) (*opcua.Client, error) {
 	return opcua.NewClient(d.ServiceConfig.OPCUAServer.Endpoint, opts...), nil
 }
 
-func (d *Driver) ConfigureMonitoredItems(sub *opcua.Subscription, reource REsourceGetter, resources, deviceName string) error {
+func (d *Driver) ConfigureMonitoredItems(sub *opcua.Subscription, resources, deviceName string) error {
 	d.Logger.Infof("[Incoming listener] Start configuring for resources.", resources)
+	ds := service.RunningService()
+	if ds == nil {
+		return fmt.Errorf(basicErrorMessage)
+	}
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	for i, node := range strings.Split(resources, ",") {
-		deviceResource, ok := reource.DeviceResource(deviceName, node)
+		deviceResource, ok := ds.DeviceResource(deviceName, node)
 		if !ok {
-			// If a resource cannot be found, skip it so subscriptions for the other resources can run.
-			d.Logger.Infof("[Incoming listener] Unable to find device resource with name %s . Please check device profile.", node)
-			continue
+			// If a resource is missing, skip it so subscriptions for the other resources can run.
+			d.Logger.Infof("[Incoming listener] Unable to find device resource with name %s", node)
+			break
 		}
 
 		opcuaNodeID, err := GetNodeID(deviceResource.Attributes, NODE)

--- a/internal/driver/subscriptionlistener.go
+++ b/internal/driver/subscriptionlistener.go
@@ -200,7 +200,9 @@ func (d *Driver) configureMonitoredItems(sub *opcua.Subscription, resources, dev
 	for i, node := range strings.Split(resources, ",") {
 		deviceResource, ok := ds.DeviceResource(deviceName, node)
 		if !ok {
-			return fmt.Errorf("[Incoming listener] Unable to find device resource with name %s", node)
+			// If a resource is missing, skip it so subscriptions for the other resources can run.
+			d.Logger.Infof("[Incoming listener] Unable to find device resource with name %s", node)
+			break
 		}
 
 		opcuaNodeID, err := GetNodeID(deviceResource.Attributes, NODE)


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

# PR Checklist

> **If your build fails** due to your commit message not passing the build checks, please review the guidelines [here](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md).

Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
<!-- link to docs PR -->

## Testing Instructions

1. Setup edgex with most current opcua image based on this PR
2. start edgex environment against any (working) machine/simulator
3. Verify subsciptions are running
4. go into consul http://localhost:8500/ui/dc1/kv/edgex/devices/2.0/device-opcua/OPCUAServer/Writable/Resources/edit and add a non existant resource( meaning it does not exist in the profile.yaml of the device you connected to
5. A Log should clarify, that the unknown resource cannot be found, but subscriptions for every other resource should run normally

## New Dependency Instructions (If applicable)

<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
